### PR TITLE
Bite 1650 - Only Apply/Update k8s resources associated with Environment change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/). Additionally,
 #### Fixed
 
 *  Enable unit tests for all environment-operator packages. [[BITE-1472](https://agile-jira.pearson.com/browse/BITE-1472)]
+*  Apply/Update services that are only associated with the environment change. [[BITE-1650](https://agile-jira.pearson.com/browse/BITE-1650)]
 
 ### **[0.0.6] - 2017-09-13 [RELEASED]**
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -44,7 +44,7 @@ func (cluster *Cluster) ApplyIfChanged(newConfig *bitesize.Environment) error {
 	log.Debugf("Loading namespace: %s", newConfig.Namespace)
 	currentConfig, _ := cluster.LoadEnvironment(newConfig.Namespace)
 
-	if !diff.Compare(*newConfig, *currentConfig) {
+	if diff.Compare(*newConfig, *currentConfig) {
 
 		content, _ := json.MarshalIndent(diff.Changes(), "", "  ")
 		log.Infof("Changes:\n %s", content)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -44,9 +44,8 @@ func (cluster *Cluster) ApplyIfChanged(newConfig *bitesize.Environment) error {
 	log.Debugf("Loading namespace: %s", newConfig.Namespace)
 	currentConfig, _ := cluster.LoadEnvironment(newConfig.Namespace)
 
-	diff.Compare(*newConfig, *currentConfig)
+	if !diff.Compare(*newConfig, *currentConfig) {
 
-	if len(diff.Changes()) != 0 {
 		content, _ := json.MarshalIndent(diff.Changes(), "", "  ")
 		log.Infof("Changes:\n %s", content)
 		err = cluster.ApplyEnvironment(currentConfig, newConfig)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1,7 +1,6 @@
 package cluster
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	log "github.com/Sirupsen/logrus"
@@ -46,8 +45,7 @@ func (cluster *Cluster) ApplyIfChanged(newConfig *bitesize.Environment) error {
 
 	if diff.Compare(*newConfig, *currentConfig) {
 
-		content, _ := json.MarshalIndent(diff.Changes(), "", "  ")
-		log.Infof("Changes:\n %s", content)
+		log.Infof("Changes:\n %s", diff.Changes())
 		err = cluster.ApplyEnvironment(currentConfig, newConfig)
 	}
 	return err

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -86,7 +86,7 @@ func TestApplyEnvironment(t *testing.T) {
 	//There should be no changes between environments e1 and e2 (they will be synced with the apply below)
 	diff.Compare(*e1, *e2)
 	cluster.ApplyEnvironment(e1, e2)
-	if !diff.Compare(*e1, *e2) {
+	if diff.Compare(*e1, *e2) {
 		t.Errorf("Expected loaded environments to be equal, yet diff is: %s", changeMap)
 	}
 

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	fakerest "k8s.io/client-go/rest/fake"
 
-	"fmt"
 	faketpr "github.com/pearsontechnology/environment-operator/pkg/util/k8s/fake"
 )
 

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -86,8 +86,7 @@ func TestApplyEnvironment(t *testing.T) {
 	//There should be no changes between environments e1 and e2 (they will be synced with the apply below)
 	diff.Compare(*e1, *e2)
 	cluster.ApplyEnvironment(e1, e2)
-	diff.Compare(*e1, *e2)
-	if len(diff.Changes()) != 0 {
+	if !diff.Compare(*e1, *e2) {
 		t.Errorf("Expected loaded environments to be equal, yet diff is: %s", changeMap)
 	}
 
@@ -537,7 +536,7 @@ func TestApplyNewHPA(t *testing.T) {
 		t.Fatalf("Unexpected err: %s", err.Error())
 	}
 
-	if diff.Compare(*e1, *e2); len(diff.Changes()) != 0 {
+	if diff.Compare(*e1, *e2) {
 		t.Errorf("Expected loaded environments to be equal, yet diff is: %s", diff.Changes())
 	}
 }
@@ -608,7 +607,7 @@ func TestApplyExistingHPA(t *testing.T) {
 		t.Fatalf("Unexpected err: %s", err.Error())
 	}
 
-	if diff.Compare(*e1, *e2); len(diff.Changes()) != 0 {
+	if diff.Compare(*e1, *e2) {
 		t.Errorf("Expected loaded environments to be equal, yet diff is: %s", diff.Changes())
 	}
 }

--- a/pkg/diff/compare.go
+++ b/pkg/diff/compare.go
@@ -7,11 +7,12 @@ import (
 
 // Compare returns unified diff between two bitesize Environment configs
 // in a string
-func Compare(config1, config2 bitesize.Environment) string {
+func Compare(config1, config2 bitesize.Environment) map[string]string {
+	var m map[string]string
+	m = make(map[string]string)
 	c1 := config1
 	c2 := config2
 
-	diff := ""
 	// Following fields are ignored for diff purposes
 	c1.Tests = []bitesize.Test{}
 	c2.Tests = []bitesize.Test{}
@@ -36,12 +37,13 @@ func Compare(config1, config2 bitesize.Environment) string {
 			}
 
 			serviceDiff := compareConfig.Compare(d, s)
-
-			diff = diff + serviceDiff
+			if serviceDiff != "" {
+				m[s.Name] = serviceDiff
+			}
 		}
 	}
 
-	return diff
+	return m
 }
 
 // Can't think of a better word

--- a/pkg/diff/compare.go
+++ b/pkg/diff/compare.go
@@ -7,9 +7,10 @@ import (
 
 // Compare returns unified diff between two bitesize Environment configs
 // in a string
-func Compare(config1, config2 bitesize.Environment) map[string]string {
-	var m map[string]string
-	m = make(map[string]string)
+func Compare(config1, config2 bitesize.Environment) {
+
+	newChangeMap()
+
 	c1 := config1
 	c2 := config2
 
@@ -38,12 +39,10 @@ func Compare(config1, config2 bitesize.Environment) map[string]string {
 
 			serviceDiff := compareConfig.Compare(d, s)
 			if serviceDiff != "" {
-				m[s.Name] = serviceDiff
+				addServiceChange(s.Name, serviceDiff)
 			}
 		}
 	}
-
-	return m
 }
 
 // Can't think of a better word

--- a/pkg/diff/compare.go
+++ b/pkg/diff/compare.go
@@ -5,9 +5,9 @@ import (
 	"github.com/pearsontechnology/environment-operator/pkg/bitesize"
 )
 
-// Compare returns unified diff between two bitesize Environment configs
-// in a string
-func Compare(config1, config2 bitesize.Environment) {
+// Compare creates a changeMap for the diff between environment configs and returns a boolean if changes were detected
+func Compare(config1, config2 bitesize.Environment) bool {
+	changeDetected := false
 
 	newChangeMap()
 
@@ -40,9 +40,11 @@ func Compare(config1, config2 bitesize.Environment) {
 			serviceDiff := compareConfig.Compare(d, s)
 			if serviceDiff != "" {
 				addServiceChange(s.Name, serviceDiff)
+				changeDetected = true
 			}
 		}
 	}
+	return changeDetected
 }
 
 // Can't think of a better word

--- a/pkg/diff/compare_test.go
+++ b/pkg/diff/compare_test.go
@@ -10,7 +10,7 @@ func TestDiffEmpty(t *testing.T) {
 	a := bitesize.Environment{}
 	b := bitesize.Environment{}
 
-	if d := Compare(a, b); d != "" {
+	if d := Compare(a, b); len(d) != 0 {
 		t.Errorf("Expected diff to be empty, got: %s", d)
 	}
 
@@ -22,7 +22,7 @@ func TestIgnoreTestFields(t *testing.T) {
 		{Name: "a"},
 	}}
 
-	if d := Compare(a, b); d != "" {
+	if d := Compare(a, b); len(d) != 0 {
 		t.Errorf("Expected diff to be empty, got: %s", d)
 	}
 }
@@ -33,7 +33,7 @@ func TestIgnoreDeploymentFields(t *testing.T) {
 		Method: "bluegreen",
 	}}
 
-	if d := Compare(a, b); d != "" {
+	if d := Compare(a, b); len(d) != 0 {
 		t.Errorf("Expected diff to be empty, got: %s", d)
 	}
 }
@@ -61,7 +61,7 @@ func TestIgnoreStatusFields(t *testing.T) {
 		},
 	}
 
-	if d := Compare(a, b); d != "" {
+	if d := Compare(a, b); len(d) != 0 {
 		t.Errorf("Expected diff to be empty, got: %s", d)
 	}
 }
@@ -70,7 +70,7 @@ func TestDiffNames(t *testing.T) {
 	a := bitesize.Environment{Name: "asd"}
 	b := bitesize.Environment{Name: "asdf"}
 
-	if Compare(a, b) != "" {
+	if len(Compare(a, b)) != 0 {
 		t.Error("Expected diff, got the same")
 	}
 }
@@ -79,12 +79,12 @@ func TestDiffVersionsSame(t *testing.T) {
 	var saTests = []struct {
 		versionA string
 		versionB string
-		expected bool
+		expected int
 	}{
-		{"1", "1", true},
-		{"1", "2", false},
-		{"", "1", true},  // assume the same if environments.bitesize does not have version
-		{"1", "", false}, // assume diff  if cluster is not deployed
+		{"1", "1", 0},
+		{"1", "2", 1},
+		{"", "1", 0}, // assume the same if environments.bitesize does not have version
+		{"1", "", 1}, // assume diff  if cluster is not deployed
 	}
 
 	for _, tst := range saTests {
@@ -95,7 +95,7 @@ func TestDiffVersionsSame(t *testing.T) {
 			Name: "a", Services: []bitesize.Service{{Name: "a", Version: tst.versionB}},
 		}
 
-		if res := Compare(a, b); (res == "") != tst.expected {
+		if res := Compare(a, b); len(res) != tst.expected {
 			t.Errorf(
 				"Unexpected version compare(%s,%s) should be %t\n%s\n A %+v\n B %+v",
 				tst.versionA, tst.versionB, tst.expected, res, a.Services, b.Services,

--- a/pkg/diff/compare_test.go
+++ b/pkg/diff/compare_test.go
@@ -10,8 +10,8 @@ func TestDiffEmpty(t *testing.T) {
 	a := bitesize.Environment{}
 	b := bitesize.Environment{}
 
-	if d := Compare(a, b); len(d) != 0 {
-		t.Errorf("Expected diff to be empty, got: %s", d)
+	if Compare(a, b); len(Changes()) != 0 {
+		t.Errorf("Expected diff to be empty, got: %s", Changes())
 	}
 
 }
@@ -22,8 +22,8 @@ func TestIgnoreTestFields(t *testing.T) {
 		{Name: "a"},
 	}}
 
-	if d := Compare(a, b); len(d) != 0 {
-		t.Errorf("Expected diff to be empty, got: %s", d)
+	if Compare(a, b); len(Changes()) != 0 {
+		t.Errorf("Expected diff to be empty, got: %s", Changes())
 	}
 }
 
@@ -33,8 +33,8 @@ func TestIgnoreDeploymentFields(t *testing.T) {
 		Method: "bluegreen",
 	}}
 
-	if d := Compare(a, b); len(d) != 0 {
-		t.Errorf("Expected diff to be empty, got: %s", d)
+	if Compare(a, b); len(Changes()) != 0 {
+		t.Errorf("Expected diff to be empty, got: %s", Changes())
 	}
 }
 
@@ -61,8 +61,8 @@ func TestIgnoreStatusFields(t *testing.T) {
 		},
 	}
 
-	if d := Compare(a, b); len(d) != 0 {
-		t.Errorf("Expected diff to be empty, got: %s", d)
+	if Compare(a, b); len(Changes()) != 0 {
+		t.Errorf("Expected diff to be empty, got: %s", Changes())
 	}
 }
 
@@ -70,7 +70,7 @@ func TestDiffNames(t *testing.T) {
 	a := bitesize.Environment{Name: "asd"}
 	b := bitesize.Environment{Name: "asdf"}
 
-	if len(Compare(a, b)) != 0 {
+	if Compare(a, b); len(Changes()) != 0 {
 		t.Error("Expected diff, got the same")
 	}
 }
@@ -95,10 +95,10 @@ func TestDiffVersionsSame(t *testing.T) {
 			Name: "a", Services: []bitesize.Service{{Name: "a", Version: tst.versionB}},
 		}
 
-		if res := Compare(a, b); len(res) != tst.expected {
+		if Compare(a, b); len(Changes()) != tst.expected {
 			t.Errorf(
 				"Unexpected version compare(%s,%s) should be %t\n%s\n A %+v\n B %+v",
-				tst.versionA, tst.versionB, tst.expected, res, a.Services, b.Services,
+				tst.versionA, tst.versionB, tst.expected, Changes(), a.Services, b.Services,
 			)
 		}
 	}

--- a/pkg/diff/compare_test.go
+++ b/pkg/diff/compare_test.go
@@ -10,7 +10,7 @@ func TestDiffEmpty(t *testing.T) {
 	a := bitesize.Environment{}
 	b := bitesize.Environment{}
 
-	if Compare(a, b); len(Changes()) != 0 {
+	if Compare(a, b) {
 		t.Errorf("Expected diff to be empty, got: %s", Changes())
 	}
 
@@ -22,7 +22,7 @@ func TestIgnoreTestFields(t *testing.T) {
 		{Name: "a"},
 	}}
 
-	if Compare(a, b); len(Changes()) != 0 {
+	if Compare(a, b) {
 		t.Errorf("Expected diff to be empty, got: %s", Changes())
 	}
 }
@@ -33,7 +33,7 @@ func TestIgnoreDeploymentFields(t *testing.T) {
 		Method: "bluegreen",
 	}}
 
-	if Compare(a, b); len(Changes()) != 0 {
+	if Compare(a, b) {
 		t.Errorf("Expected diff to be empty, got: %s", Changes())
 	}
 }
@@ -61,7 +61,7 @@ func TestIgnoreStatusFields(t *testing.T) {
 		},
 	}
 
-	if Compare(a, b); len(Changes()) != 0 {
+	if Compare(a, b) {
 		t.Errorf("Expected diff to be empty, got: %s", Changes())
 	}
 }
@@ -70,7 +70,7 @@ func TestDiffNames(t *testing.T) {
 	a := bitesize.Environment{Name: "asd"}
 	b := bitesize.Environment{Name: "asdf"}
 
-	if Compare(a, b); len(Changes()) != 0 {
+	if Compare(a, b) {
 		t.Error("Expected diff, got the same")
 	}
 }
@@ -79,12 +79,12 @@ func TestDiffVersionsSame(t *testing.T) {
 	var saTests = []struct {
 		versionA string
 		versionB string
-		expected int
+		expected bool
 	}{
-		{"1", "1", 0},
-		{"1", "2", 1},
-		{"", "1", 0}, // assume the same if environments.bitesize does not have version
-		{"1", "", 1}, // assume diff  if cluster is not deployed
+		{"1", "1", false},
+		{"1", "2", true},
+		{"", "1", false}, // assume the same if environments.bitesize does not have version
+		{"1", "", true},  // assume diff  if cluster is not deployed
 	}
 
 	for _, tst := range saTests {
@@ -95,7 +95,7 @@ func TestDiffVersionsSame(t *testing.T) {
 			Name: "a", Services: []bitesize.Service{{Name: "a", Version: tst.versionB}},
 		}
 
-		if Compare(a, b); len(Changes()) != tst.expected {
+		if Compare(a, b) != tst.expected {
 			t.Errorf(
 				"Unexpected version compare(%s,%s) should be %t\n%s\n A %+v\n B %+v",
 				tst.versionA, tst.versionB, tst.expected, Changes(), a.Services, b.Services,

--- a/pkg/diff/servicechange.go
+++ b/pkg/diff/servicechange.go
@@ -1,0 +1,28 @@
+package diff
+
+import (
+	log "github.com/Sirupsen/logrus"
+)
+
+var changeMap map[string]string
+
+func newChangeMap() {
+	changeMap = make(map[string]string)
+}
+
+func addServiceChange(svc, diff string) {
+	changeMap[svc] = diff
+}
+
+func ServiceChanged(serviceName string) bool {
+	val, serviceChangeExists := changeMap[serviceName]
+	if serviceChangeExists {
+		log.Debugf("Applying changes to the '%s' service:\n %s", serviceName, val)
+		return true
+	}
+	return false
+}
+
+func Changes() map[string]string {
+	return changeMap
+}

--- a/pkg/diff/servicechange.go
+++ b/pkg/diff/servicechange.go
@@ -1,9 +1,5 @@
 package diff
 
-import (
-	log "github.com/Sirupsen/logrus"
-)
-
 var changeMap map[string]string
 
 func newChangeMap() {

--- a/pkg/diff/servicechange.go
+++ b/pkg/diff/servicechange.go
@@ -15,9 +15,9 @@ func addServiceChange(svc, diff string) {
 }
 
 func ServiceChanged(serviceName string) bool {
-	val, serviceChangeExists := changeMap[serviceName]
+	_, serviceChangeExists := changeMap[serviceName]
+
 	if serviceChangeExists {
-		log.Debugf("Applying changes to the '%s' service:\n %s", serviceName, val)
 		return true
 	}
 	return false

--- a/pkg/diff/servicechange_test.go
+++ b/pkg/diff/servicechange_test.go
@@ -1,0 +1,18 @@
+package diff
+
+import (
+	"testing"
+)
+
+func TestAddAndRetrieveChange(t *testing.T) {
+
+	newChangeMap()
+
+	addServiceChange("testservice", "diff string")
+
+	if !ServiceChanged("testservice") {
+		t.Errorf("Expected the service should have changed, but was: %s", Changes())
+
+	}
+
+}

--- a/pkg/translator/kubemapper.go
+++ b/pkg/translator/kubemapper.go
@@ -160,13 +160,17 @@ func (w *KubeMapper) Deployment() (*v1beta1.Deployment, error) {
 func (w *KubeMapper) imagePullSecrets() ([]v1.LocalObjectReference, error) {
 	var retval []v1.LocalObjectReference
 
-	result := strings.Split(util.RegistrySecrets(), ",")
-	for i := range result {
-		var namevalue v1.LocalObjectReference
-		namevalue = v1.LocalObjectReference{
-			Name: result[i],
+	pullSecrets := util.RegistrySecrets()
+
+	if pullSecrets != "" {
+		result := strings.Split(util.RegistrySecrets(), ",")
+		for i := range result {
+			var namevalue v1.LocalObjectReference
+			namevalue = v1.LocalObjectReference{
+				Name: result[i],
+			}
+			retval = append(retval, namevalue)
 		}
-		retval = append(retval, namevalue)
 	}
 
 	return retval, nil

--- a/test/assets/environments2.bitesize
+++ b/test/assets/environments2.bitesize
@@ -1,0 +1,30 @@
+project: test
+environments:
+- name: environment2
+  namespace: environment-dev
+  services:
+  - name: service1_environment2
+    external_url: www.test.com
+    volumes:
+    - name: vol1
+      size: 1G
+      path: /tmp/asd
+      modes: ReadWriteMany
+  - name: service2_environment2
+  - name: hpaservice
+    application: gummybears
+    version: 1
+    requests:
+      cpu: 500m
+    hpa:
+      min_replicas: 2
+      max_replicas: 5
+      target_cpu_utilization_percentage: 75
+  - name: annotated_service
+    version: 1
+    annotations:
+      - name: prometheus.io/scrape
+        value: true
+      - name: prometheus.io/path
+        value: /metrics
+


### PR DESCRIPTION
- **What does the PR do?** *Fixes https://agile-jira.pearson.com/browse/BITE-1650 . This change also ensures ImagePullSecrets in the PodSpec is omitted if environment-operator is not using DOCKER_PULL_SECRETS*
- **What automated testing exists for this change?** *Unit tests updated for changes*
- **Is there documentation?** *N/A*
- **Any dependencies?** *No*
- [x] **Has the changelog been updated?** 
