### PR TITLE
Invalid name of git remote repository

### DIFF
--- a/docs/Operatonal_Guide.md
+++ b/docs/Operatonal_Guide.md
@@ -119,7 +119,7 @@ Then execute the following commands to verify git clone fails:
 echo $GIT_PRIVATE_KEY > /tmp/key
 chmod 0400 /tmp/key
 export GIT_SSH_COMMAND="ssh -i /tmp/key"
-git clone $GIT_REMOTE_POSITORY
+git clone $GIT_REMOTE_REPOSITORY
 ```
 
 This should give you the error environment-operator encounters.


### PR DESCRIPTION
git remote repository name is mentioned invalidly in instructions 

git clone $GIT_REMOTE_POSITORY

- **What does the PR do?** *(JIRA reference, background context, references to other tickets)*
Modify Documentation
- **What automated testing exists for this change?** *Link to new or existing unit tests*
N/A
- **Is there documentation?** *If yes, please provide a link to the docs.prsn.io page or appropriate Readme*
N/A
- **Any dependencies?** *(PRs in other repos that need to be merged alongside this)* N/A
- [x] **Has the changelog been updated?** 
