### PR TITLE
 ScaleTargetRef set  APIVersion: extensions/v1beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/). Additionally,
 - **Fixed** for any bug fixes.
 - **Security** for any security changes or fixes for vulnerabilities.
 
+### **[0.0.22] 2019-02-08 [RELEASED]**
+ #### Fixed
+  * Fix HPA scaleTargetRef API version  [BITE-4676](https://agile-jira.pearson.com/browse/BITE-4676)
+
 ### **[0.0.21] 2019-02-06 [RELEASED]**
  #### Added
   * Added support for complex data structures in options [BITE-4641](https://agile-jira.pearson.com/browse/BITE-4641)

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -614,7 +614,7 @@ func TestApplyExistingHPA(t *testing.T) {
 				ScaleTargetRef: autoscale_v1.CrossVersionObjectReference{
 					Kind:       "Deployment",
 					Name:       "hpa-service",
-					APIVersion: "v1beta1",
+					APIVersion: "extensions/v1beta1",
 				},
 				MinReplicas:                    &min,
 				MaxReplicas:                    5,

--- a/pkg/translator/kubemapper.go
+++ b/pkg/translator/kubemapper.go
@@ -405,7 +405,7 @@ func (w *KubeMapper) HPA() (autoscale_v1.HorizontalPodAutoscaler, error) {
 			ScaleTargetRef: autoscale_v1.CrossVersionObjectReference{
 				Kind:       "Deployment",
 				Name:       w.BiteService.Name,
-				APIVersion: "v1beta1",
+				APIVersion: "extensions/v1beta1",
 			},
 			MinReplicas:                    &w.BiteService.HPA.MinReplicas,
 			MaxReplicas:                    w.BiteService.HPA.MaxReplicas,

--- a/pkg/util/k8s/horizontal_pod_autoscaler_test.go
+++ b/pkg/util/k8s/horizontal_pod_autoscaler_test.go
@@ -29,7 +29,7 @@ func TestHPACreate(t *testing.T) {
 			ScaleTargetRef: autoscale_v1.CrossVersionObjectReference{
 				Kind:       "Deployment",
 				Name:       "newdeployment",
-				APIVersion: "v1beta1",
+				APIVersion: "extensions/v1beta1",
 			},
 			MinReplicas:                    min,
 			MaxReplicas:                    int32(3),
@@ -65,7 +65,7 @@ func TestHPAUpdate(t *testing.T) {
 			ScaleTargetRef: autoscale_v1.CrossVersionObjectReference{
 				Kind:       "Deployment",
 				Name:       "newdeployment",
-				APIVersion: "v1beta1",
+				APIVersion: "extensions/v1beta1",
 			},
 			MinReplicas:                    &min,
 			MaxReplicas:                    int32(3),
@@ -104,7 +104,7 @@ func TestHPAApplyNew(t *testing.T) {
 			ScaleTargetRef: autoscale_v1.CrossVersionObjectReference{
 				Kind:       "Deployment",
 				Name:       "newdeployment",
-				APIVersion: "v1beta1",
+				APIVersion: "extensions/v1beta1",
 			},
 			MinReplicas:                    &min,
 			MaxReplicas:                    int32(3),
@@ -139,7 +139,7 @@ func TestHPAApplyExisting(t *testing.T) {
 			ScaleTargetRef: autoscale_v1.CrossVersionObjectReference{
 				Kind:       "Deployment",
 				Name:       "newdeployment",
-				APIVersion: "v1beta1",
+				APIVersion: "extensions/v1beta1",
 			},
 			MinReplicas:                    &min,
 			MaxReplicas:                    int32(3),
@@ -226,7 +226,7 @@ func createFakeHPAClientset() *fake.Clientset {
 				ScaleTargetRef: autoscale_v1.CrossVersionObjectReference{
 					Kind:       "Deployment",
 					Name:       "fakedeployment",
-					APIVersion: "v1beta1",
+					APIVersion: "extensions/v1beta1",
 				},
 				MinReplicas:                    &min,
 				MaxReplicas:                    int32(3),

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version for environment-operator
-var Version = "0.0.21"
+var Version = "0.0.22"


### PR DESCRIPTION
This PR fixes a bug causing HPA to return <unknown> due to wrong API version set in ScaleTargetRef https://agile-jira.pearson.com/browse/BITE-4676

