### PR TITLE
Ingress fix bluegreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/). Additionally,
 - **Fixed** for any bug fixes.
 - **Security** for any security changes or fixes for vulnerabilities.
 
+### **[1.2.3] 2019-05-09 [RELEASED]**
+ #### Fixed
+  * Fixed a bug with blue/green deployments where external URL change was not reflected correctly
+
 ### **[1.2.2] 2019-05-08 [RELEASED]**
  #### Fixed
   * Fixed volume mount issue with init containers [BITE-5404](https://agile-jira.pearson.com/browse/BITE-5404)
@@ -21,7 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/). Additionally,
  #### Added
   * Bug fix - Reaper doesn't remove old configs if number of configmaps are 1
   * USE_AUTH environment variable default to true (previous default)
-  * Introduce new env variables for env git client (documented)
+
     * `GISTS_USER`
     * `GISTS_TOKEN`
     * `GISTS_PRIVATE_KEY`

--- a/pkg/diff/compare.go
+++ b/pkg/diff/compare.go
@@ -48,6 +48,14 @@ func Compare(desiredCfg, existingCfg bitesize.Environment) bool {
 				addServiceChange(desiredCfgSvc.Name, compareConfig.Compare(nil, desiredCfgSvc))
 				continue
 			}
+
+			if serviceDiff := compareConfig.Compare(existingCfgSvc.ExternalURL, desiredCfgSvc.ExternalURL); serviceDiff != "" {
+				log.Debugf("change detected for blue/green service %s", desiredCfgSvc.Name)
+				log.Tracef("changes: %v", serviceDiff)
+				addServiceChange(desiredCfgSvc.Name, serviceDiff)
+				continue
+			}
+
 			if serviceDiff := compareConfig.Compare(existingCfgSvc.ActiveDeploymentName(), desiredCfgSvc.ActiveDeploymentName()); serviceDiff != "" {
 				log.Debugf("change detected for blue/green service %s", desiredCfgSvc.Name)
 				log.Tracef("changes: %v", serviceDiff)

--- a/pkg/diff/compare_test.go
+++ b/pkg/diff/compare_test.go
@@ -113,6 +113,79 @@ func TestQuantitiesWithDiffUnits(t *testing.T) {
 	}
 }
 
+func TestBlueGreenExternalUrls(t *testing.T) {
+	var saTests = []struct {
+		versionA []string
+		versionB []string
+		expected bool
+	}{
+		{
+			[]string{"www.a.com"},
+			[]string{"www.b.com"},
+			true,
+		},
+		{
+			[]string{"www.a.com"},
+			[]string{"www.a.com"},
+			false,
+		},
+		{
+			[]string{"www.a.com"},
+			[]string{},
+			true,
+		},
+		{
+			[]string{},
+			[]string{"www.a.com"},
+			true,
+		},
+		{
+			[]string{"www.a.com", "www.b.com"},
+			[]string{"www.a.com"},
+			true,
+		},
+		{
+			[]string{"www.a.com", "www.b.com"},
+			[]string{"www.a.com", "www.b.com"},
+			false,
+		},
+	}
+
+	for _, tst := range saTests {
+		a := bitesize.Environment{
+			Name: "e",
+			Services: []bitesize.Service{
+				{
+					Name:        "a",
+					ExternalURL: tst.versionA,
+					Deployment: &bitesize.DeploymentSettings{
+						Method: "bluegreen",
+					},
+				},
+			},
+		}
+		b := bitesize.Environment{
+			Name: "e",
+			Services: []bitesize.Service{
+				{
+					Name:        "a",
+					ExternalURL: tst.versionB,
+					Deployment: &bitesize.DeploymentSettings{
+						Method: "bluegreen",
+					},
+				},
+			},
+		}
+
+		if Compare(a, b) != tst.expected {
+			t.Errorf(
+				"Unexpected external url compare(%q, %q), should be %t, got %t \n%+v",
+				tst.versionA, tst.versionB, tst.expected, Compare(a, b), Changes(),
+			)
+		}
+	}
+}
+
 func TestDiffVersionsSame(t *testing.T) {
 	var saTests = []struct {
 		versionA string

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version for environment-operator
-var Version = "1.2.2"
+var Version = "1.2.3"


### PR DESCRIPTION
This is a bit lazy PR, but in needs a major diff logic refactor to make it proper, and I don't think there's much time for it right now. It fixes blue green "parent" service change detection when it needs to change external_url. Tested in iie-web-dev namespace.