### PR TITLE
Add TLS support for ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/). Additionally,
 - **Fixed** for any bug fixes.
 - **Security** for any security changes or fixes for vulnerabilities.
 
+### **[1.2.8] 2019-08-15 [RELEASED]**
+ #### Added
+  * Add TLS support for Ingress when `ssl: true` [BITE-5954](https://agile-jira.pearson.com/browse/BITE-5954)
+
 ### **[1.2.7] 2019-06-12 [RELEASED]**
  #### Fixed
   * Fixed nil pointer issue on new deployments [BITE-5627](https://agile-jira.pearson.com/browse/BITE-5627)

--- a/pkg/translator/kubemapper.go
+++ b/pkg/translator/kubemapper.go
@@ -758,6 +758,16 @@ func (w *KubeMapper) Ingress() (*v1beta1_ext.Ingress, error) {
 			},
 		}
 
+		if w.BiteService.Ssl == "true" {
+			tls := v1beta1_ext.IngressTLS{
+				Hosts:      []string{url},
+				SecretName: w.BiteService.Name,
+			}
+			retval.Spec.TLS = []v1beta1_ext.IngressTLS{tls}
+		} else {
+			retval.Spec.TLS = nil
+		}
+
 		// Override backend
 		if w.BiteService.Backend != "" {
 			rule.IngressRuleValue.HTTP.Paths[0].Backend.ServiceName = w.BiteService.Backend

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version for environment-operator
-var Version = "1.2.7"
+var Version = "1.2.8"


### PR DESCRIPTION
Add TLS support for ingress when `ssl ` field is set to 'true'.

```
tls:
  - hosts:
    - sslexample.foo.com
    secretName: testsecret-tls
```
