### PR TITLE
Ignore services which don't have an `external_url` attribute

### DIFF
--- a/pkg/bitesize/service.go
+++ b/pkg/bitesize/service.go
@@ -244,7 +244,7 @@ func (e Service) ExternalSecretExist(namespace, name string) bool {
 		return false
 	}
 
-	if e.IsTLSEnabled() && client.ExternalSecret().Exist(name) {
+	if client.ExternalSecret().Exist(name) {
 		return true
 	}
 

--- a/pkg/diff/compare.go
+++ b/pkg/diff/compare.go
@@ -80,8 +80,8 @@ func Compare(desiredCfg, existingCfg bitesize.Environment) bool {
 			}
 		}
 
-		if k8s.ExternalSecretsEnabled && !desiredCfgSvc.ExternalSecretExist(desiredCfg.Namespace, desiredCfgSvc.Name) {
-			log.Debugf("changes detected for externalsecrets in %s for %s", desiredCfg.Namespace, desiredCfgSvc.Name)
+		if k8s.ExternalSecretsEnabled && desiredCfgSvc.IsTLSEnabled() && !desiredCfgSvc.ExternalSecretExist(desiredCfg.Namespace, desiredCfgSvc.Name) {
+			log.Debugf("changes detected for externalsecrets for %s", desiredCfgSvc.Name)
 			addServiceChange(desiredCfgSvc.Name, fmt.Sprintf("ExternalSecrets: +%s", desiredCfgSvc.Name))
 		}
 	}


### PR DESCRIPTION
- **What does the PR do?** This will ignore the searching for changes in services that don't have an `external_url` attribute.
- **What automated testing exists for this change?** NA
- **Is there documentation?** NA
- **Any dependencies?** NA
- [x] **Has the changelog been updated?** 
