### PR TITLE
1.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/). Additionally,
 - **Fixed** for any bug fixes.
 - **Security** for any security changes or fixes for vulnerabilities.
 
-### **[1.4.1] [UNRELEASED]**
+### **[1.4.1] [RELEASED]**
  #### Changed
   * Volumes are sorted before comparing desired and existing state
   * Environment variables from secrets compare properly without the key specified

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version for environment-operator
-var Version = "1.3.9"
+var Version = "1.4.1"


### PR DESCRIPTION
- **What does the PR do?**

1.4.0's release version wasn't updated so this creates 1.4.1 to properly display the version in EO startup log

- **What automated testing exists for this change?**

n/a

- **Is there documentation?**

n/a

- **Any dependencies?**

No
- [x] **Has the changelog been updated?** 
